### PR TITLE
fixed import error for python version 3.9+

### DIFF
--- a/badx12/common/click.py
+++ b/badx12/common/click.py
@@ -1,7 +1,10 @@
 # -*- coding: utf-8 -*-
-from collections import Iterable
-
 import click
+
+try:
+    from collections.abc import Iterable
+except ImportError:
+    from collections import Iterable
 
 
 def add_commands(click_group, commands):


### PR DESCRIPTION
Fix for issue: https://github.com/albmarin/badX12/issues/210

Tested imports for python `3.6.0`, `3.9.2` and `3.10.0`

<img width="981" alt="Screenshot 2023-12-22 at 12 52 13 AM" src="https://github.com/albmarin/badX12/assets/150755402/ec170d9c-bd40-4304-bbae-1585bc76bc60">


<img width="982" alt="Screenshot 2023-12-22 at 12 53 52 AM" src="https://github.com/albmarin/badX12/assets/150755402/68e977da-09d1-43fd-9a36-6a6ae8abe3c3">


<img width="1075" alt="Screenshot 2023-12-22 at 12 55 00 AM" src="https://github.com/albmarin/badX12/assets/150755402/f208f5b0-46f9-4253-aaf2-63da48f5ca8a">

